### PR TITLE
Streamline CONTRIBUTING.md with new contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,73 +1,71 @@
-# Contributing to Eclipse 4DIAC
+# Contributing to 4diac Examples
 
 Thanks for your interest in this project.
 
 ## Project description
 
-Eclipse 4diac™ in its current form has been started 2007 as an open source
-project fostering the further development of IEC 61499 for its use in
-distributed Industrial Process Measurement and Control Systems (IPMCS) and to
-further distribute research results from the original contributors. From the
-beginning, it has provided everything that is necessary to program and execute
-distributed IPMCS.
+[Eclipse 4diac](https://eclipse.dev/4diac) is an Open Source Framework for Industrial Automation & Control. 
+It is a reference implementation for the IEC 61499 standard. 
+IEC 61499 defines a domain specific modeling language for developing distributed industrial control solutions.
+IEC 61499 extends IEC 61131-3 by improving the encapsulation of software components for increased re-usability, providing a vendor independent format, and simplifying support for controller to controller communication.
+Its distribution functionality and the inherent support for dynamic reconfiguration provide the required infrastructure for Industrie 4.0 and industrial IoT applications
 
-* https://projects.eclipse.org/projects/iot.4diac
+### What is 4diac Examples
 
-## Developer resources
+4diac Examples holds a collection of IEC 61499 projects to serve as examples and reference implementations of standard control problems with IEC 61499.
 
-Information regarding source code management, builds, coding standards, and
-more.
+## Terms of Use
 
-* https://projects.eclipse.org/projects/iot.4diac/developer
+This repository is subject to the [Terms of Use of the Eclipse Foundation](https://www.eclipse.org/legal/termsofuse.php).
 
-The project maintains the following source code repositories
+## Ways to Contribute
 
-* https://git.eclipse.org/r/plugins/gitiles/4diac/org.eclipse.4diac.examples
-* https://git.eclipse.org/r/plugins/gitiles/4diac/org.eclipse.4diac.forte
-* https://git.eclipse.org/r/plugins/gitiles/4diac/org.eclipse.4diac.ide
+Contributions are welcome in many forms including:
 
-This project uses Bugzilla to track ongoing development and issues.
+- bug reports and issue reproduction
+- code contributions
+- documentation improvements
+- usability and UI improvements
+- testing and validation
 
-* Search for issues: https://bugs.eclipse.org/bugs/buglist.cgi?product=4DIAC
-* Create a new report:
-   https://bugs.eclipse.org/bugs/enter_bug.cgi?product=4DIAC
+See the [Eclipse 4diac contribute page](https://eclipse.dev/4diac/contribute/) for details.
 
-Be sure to search for existing bugs before you create another one. Remember that
-contributions are always welcome!
 
-An overview on what kinds of contributions are possible can be found here:
-* https://www.eclipse.org/4diac/en_contribute.php
+## Contribution Guide
 
-A detailed decomentation of the contribution process here:
-* https://www.eclipse.org/4diac/en_help.php?helppage=html/development/contribute.html
+The development workflow, pull request process, commit guidelines, and testing expectations are described in the 
+[Eclipse 4diac contribution guide](https://eclipse.dev/4diac/doc/development/contribute.html)
+
+## Development Environment
+
+To build and develop the 4diac Examples you need:
+
+- 4diac IDE
+- 4diac FORTE
+- 4diac FBE
 
 
 ## Eclipse Development Process
 
-This Eclipse Foundation open project is governed by the Eclipse Foundation
-Development Process and operates under the terms of the Eclipse IP Policy.
-
-* https://eclipse.org/projects/dev_process
-* https://www.eclipse.org/org/documents/Eclipse_IP_Policy.pdf
+This project operates under the [Eclipse Foundation development process](https://eclipse.org/projects/dev_process) and [IP policy](https://www.eclipse.org/org/documents/Eclipse_IP_Policy.pdf).
 
 ## Eclipse Contributor Agreement
 
-In order to be able to contribute to Eclipse Foundation projects you must
-electronically sign the Eclipse Contributor Agreement (ECA).
+Before your contribution can be accepted you must sign the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
 
-* http://www.eclipse.org/legal/ECA.php
+The ECA provides the Eclipse Foundation with a permanent record that you agree that each of your contributions will comply with the commitments documented in the Developer Certificate of Origin (DCO). 
+Having an ECA on file associated with the email address matching the "Author" field of your contribution's Git commits fulfills the DCO's requirement that you sign-off on your contributions.
 
-The ECA provides the Eclipse Foundation with a permanent record that you agree
-that each of your contributions will comply with the commitments documented in
-the Developer Certificate of Origin (DCO). Having an ECA on file associated with
-the email address matching the "Author" field of your contribution's Git commits
-fulfills the DCO's requirement that you sign-off on your contributions.
+For more information, please see the [Eclipse Committer Handbook](https://www.eclipse.org/projects/handbook/#resources-commit)
 
-For more information, please see the Eclipse Committer Handbook:
-https://www.eclipse.org/projects/handbook/#resources-commit
+
+**Ensure that:**
+- the email in your Git commits matches your Eclipse account
+- your GitHub username is linked to your Eclipse account
+
 
 ## Contact
 
-Contact the project developers via the project's "dev" list.
+Project discussions take place via:
 
-* https://dev.eclipse.org/mailman/listinfo/4diac-dev
+- [Eclipse 4diac mailing list](https://accounts.eclipse.org/mailing-list/4diac-dev)


### PR DESCRIPTION
To reduce duplicated information the CONTRIBUTING.md now focuses on the core repo specific topics and otherwise links to the respective pages on our web-page.

Furthermore relevant sections from the Eclipse project handbook's template for contributing.md have been added.