### PR TITLE
update subapp sizes for 4diac 3.0.2

### DIFF
--- a/compliance_tests/ReferenceExamples.sys
+++ b/compliance_tests/ReferenceExamples.sys
@@ -1,400 +1,400 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<System Name="ReferenceExamples" Comment="">
+<System Name="ReferenceExamples">
 	<VersionInfo Version="1.0" Author="AK115394" Date="2022-06-27">
 	</VersionInfo>
-	<Application Name="_01_EventConnections" Comment="">
+	<Application Name="_01_EventConnections">
 		<SubAppNetwork>
-			<SubApp Name="Ex1a" Comment="simple event connection  &amp;#10;- trigger E_SPLIT.EI  &amp;#10;- expect E_REND.EO" x="-2546.666666666667" y="-920.0">
+			<SubApp Name="Ex1a" Comment="simple event connection  &#10;- trigger E_SPLIT.EI  &#10;- expect E_REND.EO" x="-2600" y="-900">
 				<SubAppInterfaceList>
 				</SubAppInterfaceList>
 				<SubAppNetwork>
-					<FB Name="E_SPLIT" Type="E_SPLIT" Comment="" x="93.33333333333334" y="40.0">
+					<FB Name="E_SPLIT" Type="E_SPLIT" x="93.33" y="40">
 					</FB>
-					<FB Name="E_REND" Type="E_REND" Comment="" x="1113.3333333333335" y="40.0">
+					<FB Name="E_REND" Type="E_REND" x="1113.33" y="40">
 					</FB>
 					<EventConnections>
-						<Connection Source="E_SPLIT.EO1" Destination="E_REND.EI1" Comment=""/>
-						<Connection Source="E_SPLIT.EO2" Destination="E_REND.EI2" Comment=""/>
+						<Connection Source="E_SPLIT.EO1" Destination="E_REND.EI1"/>
+						<Connection Source="E_SPLIT.EO2" Destination="E_REND.EI2"/>
 					</EventConnections>
 				</SubAppNetwork>
-				<Attribute Name="Unfolded" Type="STRING" Value="true"/>
-				<Attribute Name="width" Type="LREAL" Value="1913.3333333333335"/>
-				<Attribute Name="height" Type="LREAL" Value="1446.6666666666667"/>
+				<Attribute Name="Unfolded" Value="true"/>
+				<Attribute Name="width" Type="LREAL" Value="2486.67"/>
+				<Attribute Name="height" Type="LREAL" Value="1446.67"/>
 			</SubApp>
-			<SubApp Name="Ex1b" Comment="simple event connection across several FBs   &amp;#10;- trigger E_SPLIT.EI    &amp;#10;- expect E_REND.EO and &amp;#10;   E_SPLIT2.EO1 and E_SPLIT2.EO2" x="-360.0" y="-933.3333333333334">
+			<SubApp Name="Ex1b" Comment="simple event connection across several FBs   &#10;- trigger E_SPLIT.EI    &#10;- expect E_REND.EO and &#10;   E_SPLIT2.EO1 and E_SPLIT2.EO2" x="0" y="-900">
 				<SubAppInterfaceList>
 				</SubAppInterfaceList>
 				<SubAppNetwork>
-					<FB Name="E_SPLIT" Type="E_SPLIT" Comment="" x="60.0" y="40.0">
+					<FB Name="E_SPLIT" Type="E_SPLIT" x="60" y="40">
 					</FB>
-					<FB Name="E_SPLIT2" Type="E_SPLIT" Comment="" x="2106.666666666667" y="40.0">
+					<FB Name="E_SPLIT2" Type="E_SPLIT" x="2106.67" y="40">
 					</FB>
-					<FB Name="E_REND" Type="E_REND" Comment="" x="1093.3333333333335" y="40.0">
+					<FB Name="E_REND" Type="E_REND" x="1093.33" y="40">
 					</FB>
 					<EventConnections>
-						<Connection Source="E_SPLIT.EO1" Destination="E_REND.EI1" Comment=""/>
-						<Connection Source="E_SPLIT.EO2" Destination="E_REND.EI2" Comment=""/>
-						<Connection Source="E_REND.EO" Destination="E_SPLIT2.EI" Comment=""/>
+						<Connection Source="E_SPLIT.EO1" Destination="E_REND.EI1"/>
+						<Connection Source="E_SPLIT.EO2" Destination="E_REND.EI2"/>
+						<Connection Source="E_REND.EO" Destination="E_SPLIT2.EI"/>
 					</EventConnections>
 				</SubAppNetwork>
-				<Attribute Name="Unfolded" Type="STRING" Value="true"/>
-				<Attribute Name="width" Type="LREAL" Value="2973.3333333333335"/>
-				<Attribute Name="height" Type="LREAL" Value="1573.3333333333335"/>
+				<Attribute Name="Unfolded" Value="true"/>
+				<Attribute Name="width" Type="LREAL" Value="3533.33"/>
+				<Attribute Name="height" Type="LREAL" Value="1446.67"/>
 			</SubApp>
-			<SubApp Name="Ex5a" Comment="example involving simple FB and basic FB type &amp;#10;- trigger E_PERMIT.EI &amp;#10;- expect SimpleIO.CNF, DOI1 := TRUE" x="-2546.666666666667" y="5173.333333333334">
+			<SubApp Name="Ex5a" Comment="example involving simple FB and basic FB type &#10;- trigger E_PERMIT.EI &#10;- expect SimpleIO.CNF, DOI1 := TRUE" x="-2546.67" y="5173.33">
 				<SubAppInterfaceList>
 				</SubAppInterfaceList>
 				<SubAppNetwork>
-					<FB Name="E_PERMIT" Type="E_PERMIT" Comment="" x="280.0" y="33.333333333333336">
+					<FB Name="E_PERMIT" Type="E_PERMIT" x="280" y="33.33">
 						<Parameter Name="PERMIT" Value="1"/>
 					</FB>
-					<FB Name="SimpleIO" Type="BOOL2BOOL" Comment="" x="1460.0" y="40.0">
+					<FB Name="SimpleIO" Type="BOOL2BOOL" x="1460" y="40">
 						<Parameter Name="IN" Value="1"/>
 					</FB>
 					<EventConnections>
-						<Connection Source="E_PERMIT.EO" Destination="SimpleIO.REQ" Comment="" dx1="180.0" dx2="180.0" dy="0.0"/>
+						<Connection Source="E_PERMIT.EO" Destination="SimpleIO.REQ" dx1="180"/>
 					</EventConnections>
 				</SubAppNetwork>
-				<Attribute Name="Unfolded" Type="STRING" Value="true"/>
-				<Attribute Name="width" Type="LREAL" Value="2686.666666666667"/>
-				<Attribute Name="height" Type="LREAL" Value="1460.0"/>
+				<Attribute Name="Unfolded" Value="true"/>
+				<Attribute Name="width" Type="LREAL" Value="2933.33"/>
+				<Attribute Name="height" Type="LREAL" Value="1460"/>
 			</SubApp>
-			<SubApp Name="Ex2a" Comment="fan-out of event connections  &amp;#10;- trigger E_SPLIT.EI  &amp;#10;- expect 2xE_MERGE.EO" x="-2546.666666666667" y="593.3333333333334">
+			<SubApp Name="Ex2a" Comment="fan-out of event connections  &#10;- trigger E_SPLIT.EI  &#10;- expect 2xE_MERGE.EO" x="-2546.67" y="593.33">
 				<SubAppInterfaceList>
 				</SubAppInterfaceList>
 				<SubAppNetwork>
-					<FB Name="E_SPLIT" Type="E_SPLIT" Comment="" x="73.33333333333334" y="13.333333333333334">
+					<FB Name="E_SPLIT" Type="E_SPLIT" x="73.33" y="13.33">
 					</FB>
-					<FB Name="E_MERGE" Type="E_MERGE" Comment="" x="1106.6666666666667" y="13.333333333333334">
+					<FB Name="E_MERGE" Type="E_MERGE" x="1106.67" y="13.33">
 					</FB>
 					<EventConnections>
-						<Connection Source="E_SPLIT.EO1" Destination="E_MERGE.EI1" Comment=""/>
-						<Connection Source="E_SPLIT.EO1" Destination="E_MERGE.EI2" Comment="" dx1="160.0"/>
+						<Connection Source="E_SPLIT.EO1" Destination="E_MERGE.EI1"/>
+						<Connection Source="E_SPLIT.EO1" Destination="E_MERGE.EI2" dx1="160"/>
 					</EventConnections>
 				</SubAppNetwork>
-				<Attribute Name="Unfolded" Type="STRING" Value="true"/>
-				<Attribute Name="width" Type="LREAL" Value="1960.0"/>
-				<Attribute Name="height" Type="LREAL" Value="1300.0"/>
+				<Attribute Name="Unfolded" Value="true"/>
+				<Attribute Name="width" Type="LREAL" Value="2540"/>
+				<Attribute Name="height" Type="LREAL" Value="1300"/>
 			</SubApp>
-			<SubApp Name="Ex3a" Comment="fan-in of event connections  &amp;#10;- trigger E_SPLIT.EI  &amp;#10;- expect 2x E_CTU.CUO, CV := 2, Q:= TRUE" x="-2546.666666666667" y="1900.0">
+			<SubApp Name="Ex3a" Comment="fan-in of event connections  &#10;- trigger E_SPLIT.EI  &#10;- expect 2x E_CTU.CUO, CV := 2, Q:= TRUE" x="-2546.67" y="1900">
 				<SubAppInterfaceList>
 				</SubAppInterfaceList>
 				<SubAppNetwork>
-					<FB Name="E_SPLIT" Type="E_SPLIT" Comment="" x="286.6666666666667" y="33.333333333333336">
+					<FB Name="E_SPLIT" Type="E_SPLIT" x="286.67" y="33.33">
 					</FB>
-					<FB Name="E_CTU" Type="E_CTU" Comment="" x="1466.6666666666667" y="40.0">
+					<FB Name="E_CTU" Type="E_CTU" x="1466.67" y="40">
 						<Parameter Name="PV" Value="2"/>
 					</FB>
 					<EventConnections>
-						<Connection Source="E_SPLIT.EO1" Destination="E_CTU.CU" Comment="" dx1="273.33333333333337"/>
-						<Connection Source="E_SPLIT.EO2" Destination="E_CTU.CU" Comment="" dx1="273.33333333333337"/>
+						<Connection Source="E_SPLIT.EO1" Destination="E_CTU.CU" dx1="273.33"/>
+						<Connection Source="E_SPLIT.EO2" Destination="E_CTU.CU" dx1="273.33"/>
 					</EventConnections>
 				</SubAppNetwork>
-				<Attribute Name="Unfolded" Type="STRING" Value="true"/>
-				<Attribute Name="width" Type="LREAL" Value="2200.0"/>
-				<Attribute Name="height" Type="LREAL" Value="1713.3333333333335"/>
+				<Attribute Name="Unfolded" Value="true"/>
+				<Attribute Name="width" Type="LREAL" Value="2860"/>
+				<Attribute Name="height" Type="LREAL" Value="1713.33"/>
 			</SubApp>
-			<SubApp Name="Ex6a" Comment="for loop  &amp;#10;- trigger 1x E_PERMIT.EI  &amp;#10;- expect 2x CUO and 2x SimpleNOT.CNF and CV := 2" x="-2886.666666666667" y="6733.333333333334">
+			<SubApp Name="Ex6a" Comment="for loop  &#10;- trigger 1x E_PERMIT.EI  &#10;- expect 2x CUO and 2x SimpleNOT.CNF and CV := 2" x="-2900" y="6700">
 				<SubAppInterfaceList>
 				</SubAppInterfaceList>
 				<SubAppNetwork>
-					<FB Name="E_CTU" Type="E_CTU" Comment="" x="1713.3333333333335" y="33.333333333333336">
+					<FB Name="E_CTU" Type="E_CTU" x="1713.33" y="33.33">
 						<Parameter Name="PV" Value="2"/>
 					</FB>
-					<FB Name="SimpleNOT" Type="SimpleNOT" Comment="" x="2746.666666666667" y="166.66666666666669">
+					<FB Name="SimpleNOT" Type="SimpleNOT" x="2746.67" y="166.67">
 					</FB>
-					<FB Name="E_PERMIT" Type="E_DEFAULT_PERMIT" Comment="" x="266.6666666666667" y="186.66666666666669">
+					<FB Name="E_PERMIT" Type="E_DEFAULT_PERMIT" x="266.67" y="186.67">
 						<Parameter Name="PERMIT" Value="TRUE"/>
 					</FB>
 					<EventConnections>
-						<Connection Source="E_CTU.CUO" Destination="SimpleNOT.REQ" Comment="" dx1="226.66666666666669" dx2="226.66666666666669" dy="0.0"/>
-						<Connection Source="SimpleNOT.CNF" Destination="E_PERMIT.EI" Comment="" dx1="80.0" dx2="80.0" dy="-386.6666666666667"/>
-						<Connection Source="E_PERMIT.EO" Destination="E_CTU.CU" Comment="" dx1="100.0"/>
+						<Connection Source="E_CTU.CUO" Destination="SimpleNOT.REQ" dx1="226.67"/>
+						<Connection Source="SimpleNOT.CNF" Destination="E_PERMIT.EI" dx1="80" dx2="80" dy="-320"/>
+						<Connection Source="E_PERMIT.EO" Destination="E_CTU.CU" dx1="100"/>
 					</EventConnections>
 					<DataConnections>
-						<Connection Source="E_CTU.Q" Destination="SimpleNOT.DI1" Comment="" dx1="226.66666666666669"/>
-						<Connection Source="SimpleNOT.DO1" Destination="E_PERMIT.PERMIT" Comment="" dx1="80.0" dx2="80.0" dy="260.0"/>
+						<Connection Source="E_CTU.Q" Destination="SimpleNOT.DI1" dx1="226.67"/>
+						<Connection Source="SimpleNOT.DO1" Destination="E_PERMIT.PERMIT" dx1="80" dx2="80" dy="260"/>
 					</DataConnections>
 				</SubAppNetwork>
-				<Attribute Name="Unfolded" Type="STRING" Value="true"/>
-				<Attribute Name="width" Type="LREAL" Value="3806.666666666667"/>
-				<Attribute Name="height" Type="LREAL" Value="1626.6666666666667"/>
+				<Attribute Name="Unfolded" Value="true"/>
+				<Attribute Name="width" Type="LREAL" Value="4260"/>
+				<Attribute Name="height" Type="LREAL" Value="1626.67"/>
 			</SubApp>
-			<SubApp Name="Ex6b" Comment="for loop  &amp;#10;- trigger 1x E_PERMIT.EI  &amp;#10;- expect no outputs" x="966.6666666666667" y="6733.333333333334">
+			<SubApp Name="Ex6b" Comment="for loop  &#10;- trigger 1x E_PERMIT.EI  &#10;- expect no outputs" x="1500" y="6700">
 				<SubAppInterfaceList>
 				</SubAppInterfaceList>
 				<SubAppNetwork>
-					<FB Name="E_PERMIT" Type="E_PERMIT" Comment="" x="320.0" y="126.66666666666667">
+					<FB Name="E_PERMIT" Type="E_PERMIT" x="320" y="126.67">
 						<Parameter Name="PERMIT" Value="FALSE"/>
 					</FB>
-					<FB Name="E_CTU" Type="E_CTU" Comment="" x="1373.3333333333335" y="33.333333333333336">
+					<FB Name="E_CTU" Type="E_CTU" x="1373.33" y="33.33">
 						<Parameter Name="PV" Value="2"/>
 					</FB>
-					<FB Name="SimpleNOT" Type="SimpleNOT" Comment="" x="2406.666666666667" y="166.66666666666669">
+					<FB Name="SimpleNOT" Type="SimpleNOT" x="2406.67" y="166.67">
 					</FB>
 					<EventConnections>
-						<Connection Source="E_PERMIT.EO" Destination="E_CTU.CU" Comment="" dx1="166.66666666666669" dx2="166.66666666666669" dy="0.0"/>
-						<Connection Source="E_CTU.CUO" Destination="SimpleNOT.REQ" Comment="" dx1="226.66666666666669" dx2="226.66666666666669" dy="0.0"/>
-						<Connection Source="SimpleNOT.CNF" Destination="E_PERMIT.EI" Comment="" dx1="80.0" dx2="80.0" dy="-386.6666666666667"/>
+						<Connection Source="E_PERMIT.EO" Destination="E_CTU.CU" dx1="166.67"/>
+						<Connection Source="E_CTU.CUO" Destination="SimpleNOT.REQ" dx1="226.67"/>
+						<Connection Source="SimpleNOT.CNF" Destination="E_PERMIT.EI" dx1="80" dx2="80" dy="-313.33"/>
 					</EventConnections>
 					<DataConnections>
-						<Connection Source="E_CTU.Q" Destination="SimpleNOT.DI1" Comment="" dx1="226.66666666666669"/>
-						<Connection Source="SimpleNOT.DO1" Destination="E_PERMIT.PERMIT" Comment="" dx1="80.0" dx2="80.0" dy="260.0"/>
+						<Connection Source="E_CTU.Q" Destination="SimpleNOT.DI1" dx1="226.67"/>
+						<Connection Source="SimpleNOT.DO1" Destination="E_PERMIT.PERMIT" dx1="80" dx2="80" dy="260"/>
 					</DataConnections>
 				</SubAppNetwork>
-				<Attribute Name="Unfolded" Type="STRING" Value="true"/>
-				<Attribute Name="width" Type="LREAL" Value="3466.666666666667"/>
-				<Attribute Name="height" Type="LREAL" Value="1626.6666666666667"/>
+				<Attribute Name="Unfolded" Value="true"/>
+				<Attribute Name="width" Type="LREAL" Value="3820"/>
+				<Attribute Name="height" Type="LREAL" Value="1626.67"/>
 			</SubApp>
-			<SubApp Name="Ex4" Comment="self-loop  &amp;#10;- trigger E_CTU.R   &amp;#10;- expect RO -&amp;gt; CUO (CV:=1)" x="-2546.666666666667" y="3566.666666666667">
+			<SubApp Name="Ex4" Comment="self-loop  &#10;- trigger E_CTU.R   &#10;- expect RO -&gt; CUO (CV:=1)" x="-2500" y="3600">
 				<SubAppInterfaceList>
 				</SubAppInterfaceList>
 				<SubAppNetwork>
-					<FB Name="E_CTU" Type="E_CTU" Comment="" x="413.33333333333337" y="0.0">
+					<FB Name="E_CTU" Type="E_CTU" x="400" y="126.67">
 						<Parameter Name="PV" Value="10"/>
 					</FB>
 					<EventConnections>
-						<Connection Source="E_CTU.RO" Destination="E_CTU.CU" Comment="" dx1="80.0" dx2="80.0" dy="-320.0"/>
+						<Connection Source="E_CTU.RO" Destination="E_CTU.CU" dx1="80" dx2="80" dy="-320"/>
 					</EventConnections>
 				</SubAppNetwork>
-				<Attribute Name="Unfolded" Type="STRING" Value="true"/>
-				<Attribute Name="width" Type="LREAL" Value="1913.3333333333335"/>
-				<Attribute Name="height" Type="LREAL" Value="1600.0"/>
+				<Attribute Name="Unfolded" Value="true"/>
+				<Attribute Name="width" Type="LREAL" Value="1913.33"/>
+				<Attribute Name="height" Type="LREAL" Value="1600"/>
 			</SubApp>
-			<Group Name="Info_EventConnections" Comment="The subapps in this App serve as test cases for various versions of event connections: &amp;#10;- simple connections &amp;#10;- fan-out &amp;#10;- fan-in  &amp;#10;- self-loop &amp;#10;- connections between different kinds of FBs &amp;#10;- a loop (repeated event connection use) &amp;#10;" x="-1753.3333333333335" y="-2400.0" width="3013.3333333333335" height="1373.3333333333335">
+			<Group Name="Info_EventConnections" Comment="The subapps in this App serve as test cases for various versions of event connections: &#10;- simple connections &#10;- fan-out &#10;- fan-in  &#10;- self-loop &#10;- connections between different kinds of FBs &#10;- a loop (repeated event connection use) &#10;" x="-1753.33" y="-2400" width="3013.33" height="1373.33" locked="false">
 			</Group>
 		</SubAppNetwork>
 	</Application>
-	<Application Name="_03_DataConnections" Comment="">
+	<Application Name="_03_DataConnections">
 		<SubAppNetwork>
-			<SubApp Name="Ex2a" Comment="fan-out of data connections &amp;#10;- trigger Fb1.REQ &amp;#10;- expect Fb2a.CNF with FB2a.OUT := TRUE AND Fb2b.CNF with FB2b.OUT" x="2873.3333333333335" y="80.0">
+			<SubApp Name="Ex2a" Comment="fan-out of data connections &#10;- trigger Fb1.REQ &#10;- expect Fb2a.CNF with FB2a.OUT := TRUE AND Fb2b.CNF with FB2b.OUT" x="2873.33" y="80">
 				<SubAppInterfaceList>
 				</SubAppInterfaceList>
 				<SubAppNetwork>
-					<FB Name="Fb1" Type="BOOL2BOOL" Comment="" x="266.6666666666667" y="146.66666666666669">
+					<FB Name="Fb1" Type="BOOL2BOOL" x="266.67" y="146.67">
 						<Parameter Name="IN" Value="TRUE"/>
 					</FB>
-					<FB Name="Fb2a" Type="BOOL2BOOL" Comment="" x="1520.0" y="0.0">
+					<FB Name="Fb2a" Type="BOOL2BOOL" x="1520" y="0">
 					</FB>
-					<FB Name="Fb2b" Type="BOOL2BOOL" Comment="" x="1513.3333333333335" y="646.6666666666667">
+					<FB Name="Fb2b" Type="BOOL2BOOL" x="1513.33" y="646.67">
 					</FB>
 					<EventConnections>
-						<Connection Source="Fb1.CNF" Destination="Fb2a.REQ" Comment="" dx1="213.33333333333334"/>
-						<Connection Source="Fb2a.CNF" Destination="Fb2b.REQ" Comment="" dx1="80.0" dx2="80.0" dy="426.6666666666667"/>
+						<Connection Source="Fb1.CNF" Destination="Fb2a.REQ" dx1="213.33"/>
+						<Connection Source="Fb2a.CNF" Destination="Fb2b.REQ" dx1="80" dx2="80" dy="426.67"/>
 					</EventConnections>
 					<DataConnections>
-						<Connection Source="Fb1.OUT" Destination="Fb2a.IN" Comment="" dx1="213.33333333333334"/>
-						<Connection Source="Fb1.OUT" Destination="Fb2b.IN" Comment="" dx1="226.66666666666669"/>
+						<Connection Source="Fb1.OUT" Destination="Fb2a.IN" dx1="213.33"/>
+						<Connection Source="Fb1.OUT" Destination="Fb2b.IN" dx1="226.67"/>
 					</DataConnections>
 				</SubAppNetwork>
-				<Attribute Name="Unfolded" Type="STRING" Value="true"/>
-				<Attribute Name="width" Type="LREAL" Value="2680.0"/>
-				<Attribute Name="height" Type="LREAL" Value="2066.666666666667"/>
+				<Attribute Name="Unfolded" Value="true"/>
+				<Attribute Name="width" Type="LREAL" Value="3060"/>
+				<Attribute Name="height" Type="LREAL" Value="2066.67"/>
 			</SubApp>
-			<SubApp Name="Ex3" Comment="example involving two kinds of FB types (simple FB type and basic FB type)   &amp;#10;trigger FB1.CUO &amp;#10;expect FB2.CNF, DOI1 := TRUE" x="2906.666666666667" y="2293.3333333333335">
+			<SubApp Name="Ex3" Comment="example involving two kinds of FB types (simple FB type and basic FB type)   &#10;trigger FB1.CUO &#10;expect FB2.CNF, DOI1 := TRUE" x="2906.67" y="2293.33">
 				<SubAppInterfaceList>
 				</SubAppInterfaceList>
 				<SubAppNetwork>
-					<FB Name="FB2" Type="BOOL2BOOL" Comment="" x="1606.6666666666667" y="46.66666666666667">
+					<FB Name="FB2" Type="BOOL2BOOL" x="1606.67" y="46.67">
 					</FB>
-					<FB Name="FB1" Type="E_CTU" Comment="" x="266.6666666666667" y="0.0">
+					<FB Name="FB1" Type="E_CTU" x="266.67" y="0">
 						<Parameter Name="PV" Value="1"/>
 					</FB>
 					<EventConnections>
-						<Connection Source="FB1.CUO" Destination="FB2.REQ" Comment="" dx1="373.33333333333337" dx2="373.33333333333337" dy="0.0"/>
+						<Connection Source="FB1.CUO" Destination="FB2.REQ" dx1="373.33"/>
 					</EventConnections>
 					<DataConnections>
-						<Connection Source="FB1.Q" Destination="FB2.IN" Comment="" dx1="380.0" dx2="380.0" dy="0.0"/>
+						<Connection Source="FB1.Q" Destination="FB2.IN" dx1="380"/>
 					</DataConnections>
 				</SubAppNetwork>
-				<Attribute Name="Unfolded" Type="STRING" Value="true"/>
-				<Attribute Name="width" Type="LREAL" Value="2566.666666666667"/>
-				<Attribute Name="height" Type="LREAL" Value="1680.0"/>
+				<Attribute Name="Unfolded" Value="true"/>
+				<Attribute Name="width" Type="LREAL" Value="3053.33"/>
+				<Attribute Name="height" Type="LREAL" Value="1680"/>
 			</SubApp>
-			<SubApp Name="Ex4a" Comment="type casts (explicit, upcast)  &amp;#10;- trigger Fb1.CU  &amp;#10;- expect Fb3.CNF and Fb3.OUT:=INT#1" x="2886.666666666667" y="4020.0">
+			<SubApp Name="Ex4a" Comment="type casts (explicit, upcast)  &#10;- trigger Fb1.CU  &#10;- expect Fb3.CNF and Fb3.OUT:=INT#1" x="2886.67" y="4020">
 				<SubAppInterfaceList>
 				</SubAppInterfaceList>
 				<SubAppNetwork>
-					<FB Name="Fb1" Type="E_CTU" Comment="" x="266.6666666666667" y="0.0">
+					<FB Name="Fb1" Type="E_CTU" x="266.67" y="0">
 						<Parameter Name="PV" Value="10"/>
 					</FB>
-					<FB Name="Fb3" Type="INT2INT" Comment="" x="2153.3333333333335" y="106.66666666666667">
+					<FB Name="Fb3" Type="INT2INT" x="2153.33" y="106.67">
 					</FB>
-					<FB Name="Fb2" Type="UINT2INT" Comment="" x="1146.6666666666667" y="113.33333333333334">
+					<FB Name="Fb2" Type="UINT2INT" x="1146.67" y="113.33">
 					</FB>
 					<EventConnections>
-						<Connection Source="Fb1.CUO" Destination="Fb2.REQ" Comment="" dx1="146.66666666666669" dx2="146.66666666666669" dy="0.0"/>
-						<Connection Source="Fb2.CNF" Destination="Fb3.REQ" Comment="" dx1="140.0"/>
+						<Connection Source="Fb1.CUO" Destination="Fb2.REQ" dx1="146.67"/>
+						<Connection Source="Fb2.CNF" Destination="Fb3.REQ" dx1="140"/>
 					</EventConnections>
 					<DataConnections>
-						<Connection Source="Fb1.CV" Destination="Fb2.IN" Comment="" dx1="146.66666666666669" dx2="146.66666666666669" dy="0.0"/>
-						<Connection Source="Fb2.OUT" Destination="Fb3.IN" Comment="" dx1="140.0"/>
+						<Connection Source="Fb1.CV" Destination="Fb2.IN" dx1="146.67"/>
+						<Connection Source="Fb2.OUT" Destination="Fb3.IN" dx1="140"/>
 					</DataConnections>
 				</SubAppNetwork>
-				<Attribute Name="Unfolded" Type="STRING" Value="true"/>
-				<Attribute Name="width" Type="LREAL" Value="2986.666666666667"/>
-				<Attribute Name="height" Type="LREAL" Value="1546.6666666666667"/>
+				<Attribute Name="Unfolded" Value="true"/>
+				<Attribute Name="width" Type="LREAL" Value="3520"/>
+				<Attribute Name="height" Type="LREAL" Value="1546.67"/>
 			</SubApp>
-			<SubApp Name="Ex1a" Comment="simple data connection (BOOL) &amp;#10;- trigger Fb1.REQ &amp;#10;- expect Fb2.CNF with Fb2.OUT:=TRUE" x="2860.0" y="-1273.3333333333335">
+			<SubApp Name="Ex1a" Comment="simple data connection (BOOL) &#10;- trigger Fb1.REQ &#10;- expect Fb2.CNF with Fb2.OUT:=TRUE" x="2860" y="-1273.33">
 				<SubAppInterfaceList>
 				</SubAppInterfaceList>
 				<SubAppNetwork>
-					<FB Name="Fb1" Type="BOOL2BOOL" Comment="" x="266.6666666666667" y="0.0">
+					<FB Name="Fb1" Type="BOOL2BOOL" x="266.67" y="0">
 						<Parameter Name="IN" Value="TRUE"/>
 					</FB>
-					<FB Name="Fb2" Type="BOOL2BOOL" Comment="" x="1340.0" y="0.0">
+					<FB Name="Fb2" Type="BOOL2BOOL" x="1340" y="0">
 					</FB>
 					<EventConnections>
-						<Connection Source="Fb1.CNF" Destination="Fb2.REQ" Comment=""/>
+						<Connection Source="Fb1.CNF" Destination="Fb2.REQ"/>
 					</EventConnections>
 					<DataConnections>
-						<Connection Source="Fb1.OUT" Destination="Fb2.IN" Comment=""/>
+						<Connection Source="Fb1.OUT" Destination="Fb2.IN"/>
 					</DataConnections>
 				</SubAppNetwork>
-				<Attribute Name="Unfolded" Type="STRING" Value="true"/>
-				<Attribute Name="width" Type="LREAL" Value="2293.3333333333335"/>
-				<Attribute Name="height" Type="LREAL" Value="1293.3333333333335"/>
+				<Attribute Name="Unfolded" Value="true"/>
+				<Attribute Name="width" Type="LREAL" Value="2686.67"/>
+				<Attribute Name="height" Type="LREAL" Value="1293.33"/>
 			</SubApp>
-			<SubApp Name="Ex1b" Comment="simple data connection (INT) &amp;#10;- trigger Fb1.REQ &amp;#10;- expect Fb2.CNF with Fb2.OUT:=5" x="5260.0" y="-1280.0">
+			<SubApp Name="Ex1b" Comment="simple data connection (INT) &#10;- trigger Fb1.REQ &#10;- expect Fb2.CNF with Fb2.OUT:=5" x="5600" y="-1300">
 				<SubAppInterfaceList>
 				</SubAppInterfaceList>
 				<SubAppNetwork>
-					<FB Name="Fb1" Type="INT2INT" Comment="" x="266.6666666666667" y="0.0">
+					<FB Name="Fb1" Type="INT2INT" x="266.67" y="0">
 						<Parameter Name="IN" Value="5"/>
 					</FB>
-					<FB Name="Fb2" Type="INT2INT" Comment="" x="1173.3333333333335" y="0.0">
+					<FB Name="Fb2" Type="INT2INT" x="1173.33" y="0">
 					</FB>
 					<EventConnections>
-						<Connection Source="Fb1.CNF" Destination="Fb2.REQ" Comment=""/>
+						<Connection Source="Fb1.CNF" Destination="Fb2.REQ"/>
 					</EventConnections>
 					<DataConnections>
-						<Connection Source="Fb1.OUT" Destination="Fb2.IN" Comment=""/>
+						<Connection Source="Fb1.OUT" Destination="Fb2.IN"/>
 					</DataConnections>
 				</SubAppNetwork>
-				<Attribute Name="Unfolded" Type="STRING" Value="true"/>
-				<Attribute Name="width" Type="LREAL" Value="2020.0"/>
-				<Attribute Name="height" Type="LREAL" Value="1293.3333333333335"/>
+				<Attribute Name="Unfolded" Value="true"/>
+				<Attribute Name="width" Type="LREAL" Value="2526.67"/>
+				<Attribute Name="height" Type="LREAL" Value="1306.67"/>
 			</SubApp>
-			<SubApp Name="Ex1c" Comment="simple data connection (WORD) &amp;#10;- trigger Fb1.REQ &amp;#10;- expect Fb2.CNF with Fb2.OUT:=AFFE" x="7346.666666666667" y="-1293.3333333333335">
+			<SubApp Name="Ex1c" Comment="simple data connection (WORD) &#10;- trigger Fb1.REQ &#10;- expect Fb2.CNF with Fb2.OUT:=AFFE" x="8200" y="-1300">
 				<SubAppInterfaceList>
 				</SubAppInterfaceList>
 				<SubAppNetwork>
-					<FB Name="Fb1" Type="WORD2WORD" Comment="" x="420.0" y="26.666666666666668">
+					<FB Name="Fb1" Type="WORD2WORD" x="420" y="26.67">
 						<Parameter Name="IN" Value="16#AFFE"/>
 					</FB>
-					<FB Name="Fb2" Type="WORD2WORD" Comment="" x="1513.3333333333335" y="20.0">
+					<FB Name="Fb2" Type="WORD2WORD" x="1513.33" y="20">
 					</FB>
 					<EventConnections>
-						<Connection Source="Fb1.CNF" Destination="Fb2.REQ" Comment="" dx1="140.0"/>
+						<Connection Source="Fb1.CNF" Destination="Fb2.REQ" dx1="140"/>
 					</EventConnections>
 					<DataConnections>
-						<Connection Source="Fb1.OUT" Destination="Fb2.IN" Comment="" dx1="140.0"/>
+						<Connection Source="Fb1.OUT" Destination="Fb2.IN" dx1="140"/>
 					</DataConnections>
 				</SubAppNetwork>
-				<Attribute Name="Unfolded" Type="STRING" Value="true"/>
-				<Attribute Name="width" Type="LREAL" Value="2720.0"/>
-				<Attribute Name="height" Type="LREAL" Value="1420.0"/>
+				<Attribute Name="Unfolded" Value="true"/>
+				<Attribute Name="width" Type="LREAL" Value="2720"/>
+				<Attribute Name="height" Type="LREAL" Value="1333.33"/>
 			</SubApp>
-			<SubApp Name="Ex2b" Comment="fan-out of data connections &amp;#10;- trigger Fb1.REQ &amp;#10;- expect Fb2a.CNF with FB2a.OUT := TRUE AND Fb2b.CNF with FB2b.OUT:=TRUE AND  &amp;#10;Fb2c.CNF with FB2c.OUT:=TRUE" x="5626.666666666667" y="73.33333333333334">
+			<SubApp Name="Ex2b" Comment="fan-out of data connections &#10;- trigger Fb1.REQ &#10;- expect Fb2a.CNF with FB2a.OUT := TRUE AND Fb2b.CNF with FB2b.OUT:=TRUE AND  &#10;Fb2c.CNF with FB2c.OUT:=TRUE" x="6000" y="100">
 				<SubAppInterfaceList>
 				</SubAppInterfaceList>
 				<SubAppNetwork>
-					<FB Name="Fb1" Type="BOOL2BOOL" Comment="" x="266.6666666666667" y="146.66666666666669">
+					<FB Name="Fb1" Type="BOOL2BOOL" x="266.67" y="146.67">
 						<Parameter Name="IN" Value="TRUE"/>
 					</FB>
-					<FB Name="Fb2a" Type="BOOL2BOOL" Comment="" x="1520.0" y="0.0">
+					<FB Name="Fb2a" Type="BOOL2BOOL" x="1520" y="0">
 					</FB>
-					<FB Name="Fb2b" Type="BOOL2BOOL" Comment="" x="1513.3333333333335" y="526.6666666666667">
+					<FB Name="Fb2b" Type="BOOL2BOOL" x="1513.33" y="526.67">
 					</FB>
-					<FB Name="Fb2b_1" Type="BOOL2BOOL" Comment="" x="1500.0" y="1086.6666666666667">
+					<FB Name="Fb2b_1" Type="BOOL2BOOL" x="1500" y="1093.33">
 					</FB>
 					<EventConnections>
-						<Connection Source="Fb1.CNF" Destination="Fb2a.REQ" Comment="" dx1="213.33333333333334"/>
-						<Connection Source="Fb2a.CNF" Destination="Fb2b.REQ" Comment="" dx1="80.0" dx2="80.0" dy="366.6666666666667"/>
-						<Connection Source="Fb2b.CNF" Destination="Fb2b_1.REQ" Comment="" dx1="80.0" dx2="80.0" dy="393.33333333333337"/>
+						<Connection Source="Fb1.CNF" Destination="Fb2a.REQ" dx1="213.33"/>
+						<Connection Source="Fb2a.CNF" Destination="Fb2b.REQ" dx1="80" dx2="80" dy="366.67"/>
+						<Connection Source="Fb2b.CNF" Destination="Fb2b_1.REQ" dx1="80" dx2="80" dy="393.33"/>
 					</EventConnections>
 					<DataConnections>
-						<Connection Source="Fb1.OUT" Destination="Fb2a.IN" Comment="" dx1="213.33333333333334"/>
-						<Connection Source="Fb1.OUT" Destination="Fb2b.IN" Comment="" dx1="226.66666666666669"/>
-						<Connection Source="Fb1.OUT" Destination="Fb2b_1.IN" Comment="" dx1="140.0"/>
+						<Connection Source="Fb1.OUT" Destination="Fb2a.IN" dx1="213.33"/>
+						<Connection Source="Fb1.OUT" Destination="Fb2b.IN" dx1="226.67"/>
+						<Connection Source="Fb1.OUT" Destination="Fb2b_1.IN" dx1="140"/>
 					</DataConnections>
 				</SubAppNetwork>
-				<Attribute Name="Unfolded" Type="STRING" Value="true"/>
-				<Attribute Name="width" Type="LREAL" Value="2680.0"/>
-				<Attribute Name="height" Type="LREAL" Value="2633.3333333333335"/>
+				<Attribute Name="Unfolded" Value="true"/>
+				<Attribute Name="width" Type="LREAL" Value="3160"/>
+				<Attribute Name="height" Type="LREAL" Value="2393.33"/>
 			</SubApp>
-			<SubApp Name="Ex4b" Comment="type casts (explicit, downcast) &amp;#10;- trigger Fb1.REQ &amp;#10;- expect Fb3.CUO and CV:=1 and Q:=TRUE" x="5993.333333333334" y="4013.3333333333335">
+			<SubApp Name="Ex4b" Comment="type casts (explicit, downcast) &#10;- trigger Fb1.REQ &#10;- expect Fb3.CUO and CV:=1 and Q:=TRUE" x="6500" y="4000">
 				<SubAppInterfaceList>
 				</SubAppInterfaceList>
 				<SubAppNetwork>
-					<FB Name="Fb1" Type="INT2INT" Comment="" x="266.6666666666667" y="6.666666666666667">
+					<FB Name="Fb1" Type="INT2INT" x="266.67" y="6.67">
 						<Parameter Name="IN" Value="1"/>
 					</FB>
-					<FB Name="Fb3" Type="E_CTU" Comment="" x="2073.3333333333335" y="0.0">
+					<FB Name="Fb3" Type="E_CTU" x="2073.33" y="0">
 					</FB>
-					<FB Name="Fb2" Type="INT2UINT" Comment="" x="1100.0" y="6.666666666666667">
+					<FB Name="Fb2" Type="INT2UINT" x="1100" y="6.67">
 					</FB>
 					<EventConnections>
-						<Connection Source="Fb1.CNF" Destination="Fb2.REQ" Comment="" dx1="100.0" dx2="100.0" dy="0.0"/>
-						<Connection Source="Fb2.CNF" Destination="Fb3.CU" Comment="" dx1="106.66666666666667"/>
+						<Connection Source="Fb1.CNF" Destination="Fb2.REQ" dx1="100"/>
+						<Connection Source="Fb2.CNF" Destination="Fb3.CU" dx1="106.67"/>
 					</EventConnections>
 					<DataConnections>
-						<Connection Source="Fb1.OUT" Destination="Fb2.IN" Comment="" dx1="86.66666666666667" dx2="86.66666666666667" dy="0.0"/>
-						<Connection Source="Fb2.OUT" Destination="Fb3.PV" Comment="" dx1="106.66666666666667"/>
+						<Connection Source="Fb1.OUT" Destination="Fb2.IN" dx1="86.67"/>
+						<Connection Source="Fb2.OUT" Destination="Fb3.PV" dx1="106.67"/>
 					</DataConnections>
 				</SubAppNetwork>
-				<Attribute Name="Unfolded" Type="STRING" Value="true"/>
-				<Attribute Name="width" Type="LREAL" Value="3073.3333333333335"/>
-				<Attribute Name="height" Type="LREAL" Value="1553.3333333333335"/>
+				<Attribute Name="Unfolded" Value="true"/>
+				<Attribute Name="width" Type="LREAL" Value="3420"/>
+				<Attribute Name="height" Type="LREAL" Value="1553.33"/>
 			</SubApp>
-			<SubApp Name="Ex5a" Comment="type casts (implicit, upcast from UINT to ANY_MAG) &amp;#10;- trigger Fb1.CU &amp;#10;- expect Fb2.CNF and Fb2.OUT:=INT#6" x="2886.666666666667" y="5580.0">
+			<SubApp Name="Ex5a" Comment="type casts (implicit, upcast from UINT to ANY_MAG) &#10;- trigger Fb1.CU &#10;- expect Fb2.CNF and Fb2.OUT:=INT#6" x="2886.67" y="5580">
 				<SubAppInterfaceList>
 				</SubAppInterfaceList>
 				<SubAppNetwork>
-					<FB Name="Fb1" Type="E_CTU" Comment="" x="266.6666666666667" y="0.0">
+					<FB Name="Fb1" Type="E_CTU" x="266.67" y="0">
 						<Parameter Name="PV" Value="10"/>
 					</FB>
-					<FB Name="Fb2" Type="F_ADD" Comment="" x="1446.6666666666667" y="33.333333333333336">
+					<FB Name="Fb2" Type="F_ADD" x="1446.67" y="33.33">
 						<Parameter Name="IN2" Value="INT#5"/>
 					</FB>
 					<EventConnections>
-						<Connection Source="Fb1.CUO" Destination="Fb2.REQ" Comment="" dx1="280.0" dx2="280.0" dy="0.0"/>
+						<Connection Source="Fb1.CUO" Destination="Fb2.REQ" dx1="280"/>
 					</EventConnections>
 					<DataConnections>
-						<Connection Source="Fb1.CV" Destination="Fb2.IN1" Comment="" dx1="166.66666666666669" dx2="166.66666666666669" dy="0.0"/>
+						<Connection Source="Fb1.CV" Destination="Fb2.IN1" dx1="166.67"/>
 					</DataConnections>
 				</SubAppNetwork>
-				<Attribute Name="Unfolded" Type="STRING" Value="true"/>
-				<Attribute Name="width" Type="LREAL" Value="3100.0"/>
-				<Attribute Name="height" Type="LREAL" Value="1673.3333333333335"/>
+				<Attribute Name="Unfolded" Value="true"/>
+				<Attribute Name="width" Type="LREAL" Value="3100"/>
+				<Attribute Name="height" Type="LREAL" Value="1673.33"/>
 			</SubApp>
-			<SubApp Name="Ex5b" Comment="type casts (implicit, upcast from UINT to ANY_MAG) &amp;#10;- trigger Fb1.CU &amp;#10;- expect Fb2.CNF and Fb2.OUT:=REAL#1.0" x="6073.333333333334" y="5586.666666666667">
+			<SubApp Name="Ex5b" Comment="type casts (implicit, upcast from UINT to ANY_MAG) &#10;- trigger Fb1.CU &#10;- expect Fb2.CNF and Fb2.OUT:=REAL#1.0" x="6073.33" y="5586.67">
 				<SubAppInterfaceList>
 				</SubAppInterfaceList>
 				<SubAppNetwork>
-					<FB Name="Fb1" Type="E_CTU" Comment="" x="266.6666666666667" y="0.0">
+					<FB Name="Fb1" Type="E_CTU" x="266.67" y="0">
 						<Parameter Name="PV" Value="10"/>
 					</FB>
-					<FB Name="Fb2" Type="REAL2REAL" Comment="" x="1446.6666666666667" y="140.0">
+					<FB Name="Fb2" Type="REAL2REAL" x="1446.67" y="140">
 					</FB>
 					<EventConnections>
-						<Connection Source="Fb1.CUO" Destination="Fb2.REQ" Comment="" dx1="300.0"/>
+						<Connection Source="Fb1.CUO" Destination="Fb2.REQ" dx1="300"/>
 					</EventConnections>
 					<DataConnections>
-						<Connection Source="Fb1.CV" Destination="Fb2.IN" Comment="" dx1="300.0"/>
+						<Connection Source="Fb1.CV" Destination="Fb2.IN" dx1="300"/>
 					</DataConnections>
 				</SubAppNetwork>
-				<Attribute Name="Unfolded" Type="STRING" Value="true"/>
-				<Attribute Name="width" Type="LREAL" Value="3100.0"/>
-				<Attribute Name="height" Type="LREAL" Value="1673.3333333333335"/>
+				<Attribute Name="Unfolded" Value="true"/>
+				<Attribute Name="width" Type="LREAL" Value="3100"/>
+				<Attribute Name="height" Type="LREAL" Value="1673.33"/>
 			</SubApp>
-			<Group Name="Info_DataConnections" Comment="The subapps in this App serve as test cases for various versions of parameters: &amp;#10;- simple boolean parameters (including counter-examples) &amp;#10;- initial value taken from type when no parameter is present &amp;#10;- parameters with prefixes &amp;#10;- upcasts in parameters" x="4133.333333333334" y="-2593.3333333333335" width="2920.0" height="1280.0">
+			<Group Name="Info_DataConnections" Comment="The subapps in this App serve as test cases for various versions of parameters: &#10;- simple boolean parameters (including counter-examples) &#10;- initial value taken from type when no parameter is present &#10;- parameters with prefixes &#10;- upcasts in parameters" x="4133.33" y="-2593.33" width="2920" height="1280" locked="false">
 			</Group>
 		</SubAppNetwork>
 	</Application>
-	<Application Name="_07_Subapplications" Comment="">
+	<Application Name="_07_Subapplications">
 		<SubAppNetwork>
-			<Group Name="__Group01" Comment="connection to the interface" x="1093.3333333333335" y="573.3333333333334" width="1333.3333333333335" height="666.6666666666667">
+			<Group Name="__Group01" Comment="connection to the interface" x="1093.33" y="573.33" width="1333.33" height="666.67" locked="false">
 			</Group>
 			<SubApp Name="DelayedTree" Comment="Three tier tree with 2 cycles with overlapping periods, and a non-overlapping delay at different levesl of the tree. The subapplication is intended to achieve different sequence of events evey run, when left running for a certain amount of time" x="2000" y="1300">
 				<SubAppInterfaceList>
@@ -410,7 +410,6 @@
 						<Parameter Name="PERMIT" Value="TRUE"/>
 					</FB>
 					<FB Name="E_CYCLE_1" Type="E_CYCLE" x="0" y="1500">
-						<Parameter Name="DT" Value="T#10ms"/>
 					</FB>
 					<FB Name="L23" Type="E_PERMIT" x="3400" y="1900">
 						<Parameter Name="PERMIT" Value="TRUE"/>
@@ -422,7 +421,6 @@
 						<Parameter Name="PERMIT" Value="TRUE"/>
 					</FB>
 					<FB Name="E_CYCLE" Type="E_CYCLE" x="0" y="900">
-						<Parameter Name="DT" Value="T#5ms"/>
 					</FB>
 					<FB Name="L21" Type="E_PERMIT" x="3400" y="700">
 						<Parameter Name="PERMIT" Value="TRUE"/>
@@ -434,7 +432,6 @@
 						<Parameter Name="PERMIT" Value="TRUE"/>
 					</FB>
 					<FB Name="E_DELAY" Type="E_DELAY" x="2700" y="1200">
-						<Parameter Name="DT" Value="T#3ms"/>
 					</FB>
 					<EventConnections>
 						<Connection Source="L0.EO" Destination="L10.EI" dx1="168.42"/>
@@ -457,349 +454,349 @@
 			</SubApp>
 		</SubAppNetwork>
 	</Application>
-	<Application Name="_06_CompositeFBs" Comment="">
+	<Application Name="_06_CompositeFBs">
 		<SubAppNetwork>
-			<Group Name="__Group01" Comment="WITH bei composite FBs" x="686.6666666666667" y="440.0" width="2040.0" height="1253.3333333333335">
+			<Group Name="__Group01" Comment="WITH bei composite FBs" x="686.67" y="440" width="2040" height="1253.33" locked="false">
 			</Group>
 		</SubAppNetwork>
 	</Application>
-	<Application Name="_02_Parameters" Comment="">
+	<Application Name="_02_Parameters">
 		<SubAppNetwork>
-			<SubApp Name="Ex2" Comment="Parameters &amp;#10; &amp;#10;- Trigger EI  &amp;#10;- Expect nothing" x="173.33333333333334" y="5646.666666666667">
+			<SubApp Name="Ex2" Comment="Parameters &#10; &#10;- Trigger EI  &#10;- Expect nothing" x="200" y="5500">
 				<SubAppInterfaceList>
 				</SubAppInterfaceList>
 				<SubAppNetwork>
-					<FB Name="E_PERMIT" Type="E_PERMIT" Comment="" x="353.33333333333337" y="13.333333333333334">
+					<FB Name="E_PERMIT" Type="E_PERMIT" x="353.33" y="13.33">
 						<Parameter Name="PERMIT" Value="0"/>
 					</FB>
 				</SubAppNetwork>
-				<Attribute Name="Unfolded" Type="STRING" Value="true"/>
-				<Attribute Name="width" Type="LREAL" Value="1740.0"/>
-				<Attribute Name="height" Type="LREAL" Value="1440.0"/>
+				<Attribute Name="Unfolded" Value="true"/>
+				<Attribute Name="width" Type="LREAL" Value="1740"/>
+				<Attribute Name="height" Type="LREAL" Value="1440"/>
 			</SubApp>
-			<SubApp Name="Ex1" Comment="Parameters overriding initial value of data type &amp;#10; &amp;#10;- Trigger E_PERMIT.EI  &amp;#10;- Expect E_PERMIT.EO" x="173.33333333333334" y="4153.333333333334">
+			<SubApp Name="Ex1" Comment="Parameters overriding initial value of data type &#10; &#10;- Trigger E_PERMIT.EI  &#10;- Expect E_PERMIT.EO" x="173.33" y="4153.33">
 				<SubAppInterfaceList>
 				</SubAppInterfaceList>
 				<SubAppNetwork>
-					<FB Name="E_PERMIT_1" Type="E_PERMIT" Comment="" x="420.0" y="0.0">
+					<FB Name="E_PERMIT_1" Type="E_PERMIT" x="420" y="0">
 						<Parameter Name="PERMIT" Value="TRUE"/>
 					</FB>
 				</SubAppNetwork>
-				<Attribute Name="Unfolded" Type="STRING" Value="true"/>
-				<Attribute Name="width" Type="LREAL" Value="1740.0"/>
-				<Attribute Name="height" Type="LREAL" Value="1546.6666666666667"/>
+				<Attribute Name="Unfolded" Value="true"/>
+				<Attribute Name="width" Type="LREAL" Value="1740"/>
+				<Attribute Name="height" Type="LREAL" Value="1246.67"/>
 			</SubApp>
-			<SubApp Name="Ex3" Comment="Initial Value (from type) &amp;#10; &amp;#10;- Trigger EI  &amp;#10;- Expect EO" x="173.33333333333334" y="7120.0">
+			<SubApp Name="Ex3" Comment="Initial Value (from type) &#10; &#10;- Trigger EI  &#10;- Expect EO" x="200" y="7000">
 				<SubAppInterfaceList>
 				</SubAppInterfaceList>
 				<SubAppNetwork>
-					<FB Name="E_PERMIT" Type="E_DEFAULT_PERMIT" Comment="" x="266.6666666666667" y="6.666666666666667">
+					<FB Name="E_PERMIT" Type="E_DEFAULT_PERMIT" x="266.67" y="6.67">
 					</FB>
 				</SubAppNetwork>
-				<Attribute Name="Unfolded" Type="STRING" Value="true"/>
-				<Attribute Name="width" Type="LREAL" Value="1793.3333333333335"/>
-				<Attribute Name="height" Type="LREAL" Value="1440.0"/>
+				<Attribute Name="Unfolded" Value="true"/>
+				<Attribute Name="width" Type="LREAL" Value="1960"/>
+				<Attribute Name="height" Type="LREAL" Value="1440"/>
 			</SubApp>
-			<SubApp Name="Ex4" Comment="Override initial value (from type) with parameter &amp;#10; &amp;#10;- Trigger EI  &amp;#10;- Expect nothing" x="173.33333333333334" y="8573.333333333334">
+			<SubApp Name="Ex4" Comment="Override initial value (from type) with parameter &#10; &#10;- Trigger EI  &#10;- Expect nothing" x="173.33" y="8453.33">
 				<SubAppInterfaceList>
 				</SubAppInterfaceList>
 				<SubAppNetwork>
-					<FB Name="E_PERMIT" Type="E_DEFAULT_PERMIT" Comment="" x="266.6666666666667" y="33.333333333333336">
+					<FB Name="E_PERMIT" Type="E_DEFAULT_PERMIT" x="300" y="40">
 						<Parameter Name="PERMIT" Value="0"/>
 					</FB>
 				</SubAppNetwork>
-				<Attribute Name="Unfolded" Type="STRING" Value="true"/>
-				<Attribute Name="width" Type="LREAL" Value="1753.3333333333335"/>
-				<Attribute Name="height" Type="LREAL" Value="1580.0"/>
+				<Attribute Name="Unfolded" Value="true"/>
+				<Attribute Name="width" Type="LREAL" Value="2320"/>
+				<Attribute Name="height" Type="LREAL" Value="1320"/>
 			</SubApp>
-			<SubApp Name="Ex6" Comment="Any type: required casts  &amp;#10; &amp;#10;- Trigger REQ &amp;#10;- Expect CNF and OUT:=13" x="146.66666666666669" y="11686.666666666668">
+			<SubApp Name="Ex6" Comment="Any type: required casts  &#10; &#10;- Trigger REQ &#10;- Expect CNF and OUT:=13" x="200" y="11400">
 				<SubAppInterfaceList>
 				</SubAppInterfaceList>
 				<SubAppNetwork>
-					<FB Name="E_PERMIT" Type="F_ADD" Comment="" x="360.0" y="0.0">
+					<FB Name="E_PERMIT" Type="F_ADD" x="360" y="0">
 						<Parameter Name="IN1" Value="INT#5"/>
 						<Parameter Name="IN2" Value="UINT#8"/>
 					</FB>
 				</SubAppNetwork>
-				<Attribute Name="Unfolded" Type="STRING" Value="true"/>
-				<Attribute Name="width" Type="LREAL" Value="1660.0"/>
-				<Attribute Name="height" Type="LREAL" Value="1546.6666666666667"/>
+				<Attribute Name="Unfolded" Value="true"/>
+				<Attribute Name="width" Type="LREAL" Value="1660"/>
+				<Attribute Name="height" Type="LREAL" Value="1546.67"/>
 			</SubApp>
-			<SubApp Name="Ex5a" Comment="integer parameter &amp;#10; &amp;#10;- Trigger REQ &amp;#10;- Expect CNF, OUT:=5" x="173.33333333333334" y="10120.0">
+			<SubApp Name="Ex5a" Comment="integer parameter &#10; &#10;- Trigger REQ &#10;- Expect CNF, OUT:=5" x="-100" y="9800">
 				<SubAppInterfaceList>
 				</SubAppInterfaceList>
 				<SubAppNetwork>
-					<FB Name="INT2INT" Type="INT2INT" Comment="" x="266.6666666666667" y="0.0">
+					<FB Name="INT2INT" Type="INT2INT" x="200" y="66.67">
 						<Parameter Name="IN" Value="5"/>
 					</FB>
 				</SubAppNetwork>
-				<Attribute Name="Unfolded" Type="STRING" Value="true"/>
-				<Attribute Name="width" Type="LREAL" Value="1300.0"/>
-				<Attribute Name="height" Type="LREAL" Value="1520.0"/>
+				<Attribute Name="Unfolded" Value="true"/>
+				<Attribute Name="width" Type="LREAL" Value="1560"/>
+				<Attribute Name="height" Type="LREAL" Value="1520"/>
 			</SubApp>
-			<SubApp Name="Ex5b" Comment="integer parameter with prefix &amp;#10; &amp;#10;- Trigger REQ &amp;#10;- Expect CNF, OUT:=5" x="1566.6666666666667" y="10106.666666666668">
+			<SubApp Name="Ex5b" Comment="integer parameter with prefix &#10; &#10;- Trigger REQ &#10;- Expect CNF, OUT:=5" x="1553.33" y="9813.33">
 				<SubAppInterfaceList>
 				</SubAppInterfaceList>
 				<SubAppNetwork>
-					<FB Name="INT2INT" Type="INT2INT" Comment="" x="553.3333333333334" y="13.333333333333334">
+					<FB Name="INT2INT" Type="INT2INT" x="553.33" y="13.33">
 						<Parameter Name="IN" Value="INT#5"/>
 					</FB>
 				</SubAppNetwork>
-				<Attribute Name="Unfolded" Type="STRING" Value="true"/>
-				<Attribute Name="width" Type="LREAL" Value="2040.0"/>
-				<Attribute Name="height" Type="LREAL" Value="1533.3333333333335"/>
+				<Attribute Name="Unfolded" Value="true"/>
+				<Attribute Name="width" Type="LREAL" Value="2040"/>
+				<Attribute Name="height" Type="LREAL" Value="1533.33"/>
 			</SubApp>
-			<SubApp Name="Ex5c" Comment="integer parameter with prefix (upcast) &amp;#10; &amp;#10;- Trigger REQ &amp;#10;- Expect CNF, OUT:=5" x="3713.3333333333335" y="10093.333333333334">
+			<SubApp Name="Ex5c" Comment="integer parameter with prefix (upcast) &#10; &#10;- Trigger REQ &#10;- Expect CNF, OUT:=5" x="3700" y="9800">
 				<SubAppInterfaceList>
 				</SubAppInterfaceList>
 				<SubAppNetwork>
-					<FB Name="INT2INT" Type="INT2INT" Comment="" x="793.3333333333334" y="0.0">
+					<FB Name="INT2INT" Type="INT2INT" x="793.33" y="0">
 						<Parameter Name="IN" Value="USINT#5"/>
 					</FB>
 				</SubAppNetwork>
-				<Attribute Name="Unfolded" Type="STRING" Value="true"/>
-				<Attribute Name="width" Type="LREAL" Value="2380.0"/>
-				<Attribute Name="height" Type="LREAL" Value="1546.6666666666667"/>
+				<Attribute Name="Unfolded" Value="true"/>
+				<Attribute Name="width" Type="LREAL" Value="2380"/>
+				<Attribute Name="height" Type="LREAL" Value="1546.67"/>
 			</SubApp>
-			<Group Name="Info_Parameters" Comment="The subapps in this App serve as test cases for various versions of parameters: &amp;#10;- simple boolean parameters (including counter-examples) &amp;#10;- initial value taken from type when no parameter is present &amp;#10;- parameters with prefixes &amp;#10;- upcasts in parameters" x="880.0" y="2773.3333333333335" width="2920.0" height="1300.0">
+			<Group Name="Info_Parameters" Comment="The subapps in this App serve as test cases for various versions of parameters: &#10;- simple boolean parameters (including counter-examples) &#10;- initial value taken from type when no parameter is present &#10;- parameters with prefixes &#10;- upcasts in parameters" x="880" y="2773.33" width="2920" height="1300" locked="false">
 			</Group>
 		</SubAppNetwork>
 	</Application>
-	<Application Name="_04_DataWith" Comment="">
+	<Application Name="_04_DataWith">
 		<SubAppNetwork>
-			<Group Name="Info_DataConnections" Comment="The subapps in this App serve as test cases for various versions of WITH-constructs (on updating data values to the outputs). &amp;#10;- WITH at the inputs &amp;#10;- WITH at the outputs" x="1893.3333333333335" y="133.33333333333334" width="2920.0" height="900.0">
+			<Group Name="Info_DataConnections" Comment="The subapps in this App serve as test cases for various versions of WITH-constructs (on updating data values to the outputs). &#10;- WITH at the inputs &#10;- WITH at the outputs" x="1893.33" y="133.33" width="2920" height="900" locked="false">
 			</Group>
-			<SubApp Name="Ex1a" Comment="trigger REQ, expect CNF and &amp;#10;DO1.OUT:=TRUE &amp;#10;DO2.OUT:=-10 &amp;#10;DO3.OUT:=15 &amp;#10;DO4.OUT:=2.0 (data values from type)" x="453.33333333333337" y="1266.6666666666667">
+			<SubApp Name="Ex1a" Comment="trigger REQ, expect CNF and &#10;DO1.OUT:=TRUE &#10;DO2.OUT:=-10 &#10;DO3.OUT:=15 &#10;DO4.OUT:=2.0 (data values from type)" x="453.33" y="1266.67">
 				<SubAppInterfaceList>
 				</SubAppInterfaceList>
 				<SubAppNetwork>
-					<FB Name="WithInputs" Type="WithInputs" Comment="" x="300.0" y="53.333333333333336">
+					<FB Name="WithInputs" Type="WithInputs" x="300" y="53.33">
 						<Parameter Name="DI1" Value="FALSE"/>
 						<Parameter Name="DI2" Value="42"/>
 						<Parameter Name="DI3" Value="21"/>
 						<Parameter Name="DI4" Value="3.14"/>
 					</FB>
-					<FB Name="DO1" Type="BOOL2BOOL" Comment="" x="1646.6666666666667" y="0.0">
+					<FB Name="DO1" Type="BOOL2BOOL" x="1646.67" y="0">
 					</FB>
-					<FB Name="DO2" Type="INT2INT" Comment="" x="1660.0" y="626.6666666666667">
+					<FB Name="DO2" Type="INT2INT" x="1660" y="626.67">
 					</FB>
-					<FB Name="DO3" Type="UINT2INT" Comment="" x="1673.3333333333335" y="1260.0">
+					<FB Name="DO3" Type="UINT2INT" x="1673.33" y="1260">
 					</FB>
-					<FB Name="DO4" Type="REAL2REAL" Comment="" x="1693.3333333333335" y="1900.0">
+					<FB Name="DO4" Type="REAL2REAL" x="1693.33" y="1900">
 					</FB>
 					<EventConnections>
-						<Connection Source="WithInputs.CNF" Destination="DO1.REQ" Comment="" dx1="233.33333333333334"/>
-						<Connection Source="DO1.CNF" Destination="DO2.REQ" Comment="" dx1="80.0" dx2="80.0" dy="400.0"/>
-						<Connection Source="DO2.CNF" Destination="DO3.REQ" Comment="" dx1="80.0" dx2="80.0" dy="380.0"/>
-						<Connection Source="DO3.CNF" Destination="DO4.REQ" Comment="" dx1="80.0" dx2="80.0" dy="386.6666666666667"/>
+						<Connection Source="WithInputs.CNF" Destination="DO1.REQ" dx1="233.33"/>
+						<Connection Source="DO1.CNF" Destination="DO2.REQ" dx1="80" dx2="80" dy="400"/>
+						<Connection Source="DO2.CNF" Destination="DO3.REQ" dx1="80" dx2="80" dy="380"/>
+						<Connection Source="DO3.CNF" Destination="DO4.REQ" dx1="80" dx2="80" dy="386.67"/>
 					</EventConnections>
 					<DataConnections>
-						<Connection Source="WithInputs.DO1" Destination="DO1.IN" Comment="" dx1="233.33333333333334"/>
-						<Connection Source="WithInputs.DO2" Destination="DO2.IN" Comment="" dx1="260.0"/>
-						<Connection Source="WithInputs.DO3" Destination="DO3.IN" Comment="" dx1="220.0"/>
-						<Connection Source="WithInputs.DO4" Destination="DO4.IN" Comment="" dx1="160.0"/>
+						<Connection Source="WithInputs.DO1" Destination="DO1.IN" dx1="233.33"/>
+						<Connection Source="WithInputs.DO2" Destination="DO2.IN" dx1="260"/>
+						<Connection Source="WithInputs.DO3" Destination="DO3.IN" dx1="220"/>
+						<Connection Source="WithInputs.DO4" Destination="DO4.IN" dx1="160"/>
 					</DataConnections>
 				</SubAppNetwork>
-				<Attribute Name="Unfolded" Type="STRING" Value="true"/>
-				<Attribute Name="width" Type="LREAL" Value="2833.3333333333335"/>
-				<Attribute Name="height" Type="LREAL" Value="3446.666666666667"/>
+				<Attribute Name="Unfolded" Value="true"/>
+				<Attribute Name="width" Type="LREAL" Value="3053.33"/>
+				<Attribute Name="height" Type="LREAL" Value="3446.67"/>
 			</SubApp>
-			<SubApp Name="Ex1b" Comment="trigger UPDATE, expect CNF and &amp;#10;DO1.OUT:=FALSE &amp;#10;DO2.OUT:=42 &amp;#10;DO3.OUT:=21 &amp;#10;DO4.OUT:=3.14 (data values from type)" x="3313.3333333333335" y="1253.3333333333335">
+			<SubApp Name="Ex1b" Comment="trigger UPDATE, expect CNF and &#10;DO1.OUT:=FALSE &#10;DO2.OUT:=42 &#10;DO3.OUT:=21 &#10;DO4.OUT:=3.14 (data values from type)" x="3600" y="1300">
 				<SubAppInterfaceList>
 				</SubAppInterfaceList>
 				<SubAppNetwork>
-					<FB Name="WithInputs" Type="WithInputs" Comment="" x="300.0" y="53.333333333333336">
+					<FB Name="WithInputs" Type="WithInputs" x="300" y="53.33">
 						<Parameter Name="DI1" Value="FALSE"/>
 						<Parameter Name="DI2" Value="42"/>
 						<Parameter Name="DI3" Value="21"/>
 						<Parameter Name="DI4" Value="3.14"/>
 					</FB>
-					<FB Name="DO1" Type="BOOL2BOOL" Comment="" x="1646.6666666666667" y="0.0">
+					<FB Name="DO1" Type="BOOL2BOOL" x="1646.67" y="0">
 					</FB>
-					<FB Name="DO2" Type="INT2INT" Comment="" x="1660.0" y="626.6666666666667">
+					<FB Name="DO2" Type="INT2INT" x="1660" y="626.67">
 					</FB>
-					<FB Name="DO3" Type="UINT2INT" Comment="" x="1673.3333333333335" y="1260.0">
+					<FB Name="DO3" Type="UINT2INT" x="1673.33" y="1260">
 					</FB>
-					<FB Name="DO4" Type="REAL2REAL" Comment="" x="1693.3333333333335" y="1900.0">
+					<FB Name="DO4" Type="REAL2REAL" x="1693.33" y="1900">
 					</FB>
 					<EventConnections>
-						<Connection Source="WithInputs.CNF" Destination="DO1.REQ" Comment="" dx1="233.33333333333334"/>
-						<Connection Source="DO1.CNF" Destination="DO2.REQ" Comment="" dx1="80.0" dx2="80.0" dy="400.0"/>
-						<Connection Source="DO2.CNF" Destination="DO3.REQ" Comment="" dx1="80.0" dx2="80.0" dy="380.0"/>
-						<Connection Source="DO3.CNF" Destination="DO4.REQ" Comment="" dx1="80.0" dx2="80.0" dy="386.6666666666667"/>
+						<Connection Source="WithInputs.CNF" Destination="DO1.REQ" dx1="233.33"/>
+						<Connection Source="DO1.CNF" Destination="DO2.REQ" dx1="80" dx2="80" dy="400"/>
+						<Connection Source="DO2.CNF" Destination="DO3.REQ" dx1="80" dx2="80" dy="380"/>
+						<Connection Source="DO3.CNF" Destination="DO4.REQ" dx1="80" dx2="80" dy="386.67"/>
 					</EventConnections>
 					<DataConnections>
-						<Connection Source="WithInputs.DO1" Destination="DO1.IN" Comment="" dx1="233.33333333333334"/>
-						<Connection Source="WithInputs.DO2" Destination="DO2.IN" Comment="" dx1="260.0"/>
-						<Connection Source="WithInputs.DO3" Destination="DO3.IN" Comment="" dx1="220.0"/>
-						<Connection Source="WithInputs.DO4" Destination="DO4.IN" Comment="" dx1="160.0"/>
+						<Connection Source="WithInputs.DO1" Destination="DO1.IN" dx1="233.33"/>
+						<Connection Source="WithInputs.DO2" Destination="DO2.IN" dx1="260"/>
+						<Connection Source="WithInputs.DO3" Destination="DO3.IN" dx1="220"/>
+						<Connection Source="WithInputs.DO4" Destination="DO4.IN" dx1="160"/>
 					</DataConnections>
 				</SubAppNetwork>
-				<Attribute Name="Unfolded" Type="STRING" Value="true"/>
-				<Attribute Name="width" Type="LREAL" Value="2833.3333333333335"/>
-				<Attribute Name="height" Type="LREAL" Value="3446.666666666667"/>
+				<Attribute Name="Unfolded" Value="true"/>
+				<Attribute Name="width" Type="LREAL" Value="3080"/>
+				<Attribute Name="height" Type="LREAL" Value="3446.67"/>
 			</SubApp>
-			<SubApp Name="Ex2a" Comment="trigger REQ, expect CNF and &amp;#10;DO1.OUT:=TRUE &amp;#10;DO2.OUT:=-42 &amp;#10;DO3.OUT:=21 &amp;#10;DO4.OUT:=3.14 (data values from type)" x="453.33333333333337" y="4966.666666666667">
+			<SubApp Name="Ex2a" Comment="trigger REQ, expect CNF and &#10;DO1.OUT:=TRUE &#10;DO2.OUT:=-42 &#10;DO3.OUT:=21 &#10;DO4.OUT:=3.14 (data values from type)" x="453.33" y="4966.67">
 				<SubAppInterfaceList>
 				</SubAppInterfaceList>
 				<SubAppNetwork>
-					<FB Name="DO1" Type="BOOL2BOOL" Comment="" x="1660.0" y="0.0">
+					<FB Name="DO1" Type="BOOL2BOOL" x="1660" y="0">
 					</FB>
-					<FB Name="DO2" Type="INT2INT" Comment="" x="1673.3333333333335" y="626.6666666666667">
+					<FB Name="DO2" Type="INT2INT" x="1673.33" y="626.67">
 					</FB>
-					<FB Name="DO3" Type="UINT2INT" Comment="" x="1686.6666666666667" y="1260.0">
+					<FB Name="DO3" Type="UINT2INT" x="1686.67" y="1260">
 					</FB>
-					<FB Name="DO4" Type="REAL2REAL" Comment="" x="1646.6666666666667" y="1886.6666666666667">
+					<FB Name="DO4" Type="REAL2REAL" x="1646.67" y="1886.67">
 					</FB>
-					<FB Name="WithOutputs" Type="WithOutputs" Comment="" x="300.0" y="0.0">
+					<FB Name="WithOutputs" Type="WithOutputs" x="300" y="0">
 						<Parameter Name="DI1" Value="FALSE"/>
 						<Parameter Name="DI2" Value="21"/>
 						<Parameter Name="DI3" Value="42"/>
 						<Parameter Name="DI4" Value="4.9"/>
 					</FB>
 					<EventConnections>
-						<Connection Source="DO1.CNF" Destination="DO2.REQ" Comment="" dx1="80.0" dx2="80.0" dy="400.0"/>
-						<Connection Source="DO2.CNF" Destination="DO3.REQ" Comment="" dx1="80.0" dx2="80.0" dy="406.6666666666667"/>
-						<Connection Source="DO3.CNF" Destination="DO4.REQ" Comment="" dx1="80.0" dx2="80.0" dy="386.6666666666667"/>
-						<Connection Source="WithOutputs.CNF" Destination="DO1.REQ" Comment=""/>
+						<Connection Source="DO1.CNF" Destination="DO2.REQ" dx1="80" dx2="80" dy="400"/>
+						<Connection Source="DO2.CNF" Destination="DO3.REQ" dx1="80" dx2="80" dy="406.67"/>
+						<Connection Source="DO3.CNF" Destination="DO4.REQ" dx1="80" dx2="80" dy="386.67"/>
+						<Connection Source="WithOutputs.CNF" Destination="DO1.REQ"/>
 					</EventConnections>
 					<DataConnections>
-						<Connection Source="WithOutputs.DO1" Destination="DO1.IN" Comment="" dx1="213.33333333333334"/>
-						<Connection Source="WithOutputs.DO2" Destination="DO2.IN" Comment="" dx1="220.0"/>
-						<Connection Source="WithOutputs.DO3" Destination="DO3.IN" Comment="" dx1="180.0"/>
-						<Connection Source="WithOutputs.DO4" Destination="DO4.IN" Comment="" dx1="120.0"/>
+						<Connection Source="WithOutputs.DO1" Destination="DO1.IN" dx1="213.33"/>
+						<Connection Source="WithOutputs.DO2" Destination="DO2.IN" dx1="220"/>
+						<Connection Source="WithOutputs.DO3" Destination="DO3.IN" dx1="180"/>
+						<Connection Source="WithOutputs.DO4" Destination="DO4.IN" dx1="120"/>
 					</DataConnections>
 				</SubAppNetwork>
-				<Attribute Name="Unfolded" Type="STRING" Value="true"/>
-				<Attribute Name="width" Type="LREAL" Value="2833.3333333333335"/>
-				<Attribute Name="height" Type="LREAL" Value="3433.3333333333335"/>
+				<Attribute Name="Unfolded" Value="true"/>
+				<Attribute Name="width" Type="LREAL" Value="3160"/>
+				<Attribute Name="height" Type="LREAL" Value="3433.33"/>
 			</SubApp>
-			<SubApp Name="Ex2b" Comment="trigger UPDATE, expect CNF and &amp;#10;DO1.OUT:=FALSE &amp;#10;DO2.OUT:=21 &amp;#10;DO3.OUT:=42 &amp;#10;DO4.OUT:=4.9 (data values from parameters)" x="3313.3333333333335" y="4960.0">
+			<SubApp Name="Ex2b" Comment="trigger UPDATE, expect CNF and &#10;DO1.OUT:=FALSE &#10;DO2.OUT:=21 &#10;DO3.OUT:=42 &#10;DO4.OUT:=4.9 (data values from parameters)" x="3646.67" y="5000">
 				<SubAppInterfaceList>
 				</SubAppInterfaceList>
 				<SubAppNetwork>
-					<FB Name="DO1" Type="BOOL2BOOL" Comment="" x="1773.3333333333335" y="0.0">
+					<FB Name="DO1" Type="BOOL2BOOL" x="1520" y="106.67">
 					</FB>
-					<FB Name="DO2" Type="INT2INT" Comment="" x="1786.6666666666667" y="626.6666666666667">
+					<FB Name="DO2" Type="INT2INT" x="1480" y="733.33">
 					</FB>
-					<FB Name="DO3" Type="UINT2INT" Comment="" x="1800.0" y="1260.0">
+					<FB Name="DO3" Type="UINT2INT" x="1493.33" y="1366.67">
 					</FB>
-					<FB Name="DO4" Type="REAL2REAL" Comment="" x="1760.0" y="1886.6666666666667">
+					<FB Name="DO4" Type="REAL2REAL" x="1453.33" y="1993.33">
 					</FB>
-					<FB Name="WithOutputs" Type="WithOutputs" Comment="" x="413.33333333333337" y="0.0">
+					<FB Name="WithOutputs" Type="WithOutputs" x="306.67" y="106.67">
 						<Parameter Name="DI1" Value="FALSE"/>
 						<Parameter Name="DI2" Value="21"/>
 						<Parameter Name="DI3" Value="42"/>
 						<Parameter Name="DI4" Value="4.9"/>
 					</FB>
 					<EventConnections>
-						<Connection Source="DO1.CNF" Destination="DO2.REQ" Comment="" dx1="80.0" dx2="80.0" dy="400.0"/>
-						<Connection Source="DO2.CNF" Destination="DO3.REQ" Comment="" dx1="80.0" dx2="80.0" dy="406.6666666666667"/>
-						<Connection Source="DO3.CNF" Destination="DO4.REQ" Comment="" dx1="80.0" dx2="80.0" dy="386.6666666666667"/>
-						<Connection Source="WithOutputs.UPDATEO" Destination="DO1.REQ" Comment="" dx1="186.66666666666669" dx2="186.66666666666669" dy="0.0"/>
+						<Connection Source="DO1.CNF" Destination="DO2.REQ" dx1="80" dx2="80" dy="313.33"/>
+						<Connection Source="DO2.CNF" Destination="DO3.REQ" dx1="80" dx2="80" dy="313.33"/>
+						<Connection Source="DO3.CNF" Destination="DO4.REQ" dx1="80" dx2="80" dy="313.33"/>
+						<Connection Source="WithOutputs.UPDATEO" Destination="DO1.REQ" dx1="126.67"/>
 					</EventConnections>
 					<DataConnections>
-						<Connection Source="WithOutputs.DO1" Destination="DO1.IN" Comment="" dx1="213.33333333333334"/>
-						<Connection Source="WithOutputs.DO2" Destination="DO2.IN" Comment="" dx1="220.0"/>
-						<Connection Source="WithOutputs.DO3" Destination="DO3.IN" Comment="" dx1="180.0"/>
-						<Connection Source="WithOutputs.DO4" Destination="DO4.IN" Comment="" dx1="120.0"/>
+						<Connection Source="WithOutputs.DO1" Destination="DO1.IN" dx1="126.67"/>
+						<Connection Source="WithOutputs.DO2" Destination="DO2.IN" dx1="86.67"/>
+						<Connection Source="WithOutputs.DO3" Destination="DO3.IN" dx1="100"/>
+						<Connection Source="WithOutputs.DO4" Destination="DO4.IN" dx1="166.67"/>
 					</DataConnections>
 				</SubAppNetwork>
-				<Attribute Name="Unfolded" Type="STRING" Value="true"/>
-				<Attribute Name="width" Type="LREAL" Value="2826.666666666667"/>
-				<Attribute Name="height" Type="LREAL" Value="3433.3333333333335"/>
+				<Attribute Name="Unfolded" Value="true"/>
+				<Attribute Name="width" Type="LREAL" Value="2826.67"/>
+				<Attribute Name="height" Type="LREAL" Value="3433.33"/>
 			</SubApp>
 		</SubAppNetwork>
 	</Application>
-	<Application Name="_05_Adapter" Comment="">
+	<Application Name="_05_Adapter">
 		<SubAppNetwork>
-			<Group Name="Info_Adapter" Comment="The subapps in this App serve as test cases for various versions of WITH-constructs (on updating data values to the outputs). &amp;#10;- WITH at the inputs &amp;#10;- WITH at the outputs" x="3520.0" y="713.3333333333334" width="2920.0" height="840.0">
+			<Group Name="Info_Adapter" Comment="The subapps in this App serve as test cases for various versions of WITH-constructs (on updating data values to the outputs). &#10;- WITH at the inputs &#10;- WITH at the outputs" x="3520" y="713.33" width="2920" height="840" locked="false">
 			</Group>
-			<SubApp Name="Ex1a" Comment="Adapter with just events &amp;#10;- trigger Fb1.REQ  &amp;#10;- expect Fb1.CNF and Fb1.RSP" x="3386.666666666667" y="1626.6666666666667">
+			<SubApp Name="Ex1a" Comment="Adapter with just events &#10;- trigger Fb1.REQ  &#10;- expect Fb1.CNF and Fb1.RSP" x="3386.67" y="1626.67">
 				<SubAppInterfaceList>
 				</SubAppInterfaceList>
 				<SubAppNetwork>
-					<FB Name="Fb1" Type="BasicAdapter2" Comment="" x="113.33333333333334" y="0.0">
+					<FB Name="Fb1" Type="BasicAdapter2" x="113.33" y="0">
 					</FB>
-					<FB Name="Fb2" Type="BasicAdapter" Comment="" x="1453.3333333333335" y="86.66666666666667">
+					<FB Name="Fb2" Type="BasicAdapter" x="1453.33" y="86.67">
 					</FB>
 					<AdapterConnections>
-						<Connection Source="Fb2.adp" Destination="Fb1.adp" Comment="" dx1="80.0" dx2="80.0" dy="366.6666666666667"/>
+						<Connection Source="Fb2.adp" Destination="Fb1.adp" dx1="80" dx2="80" dy="366.67"/>
 					</AdapterConnections>
 				</SubAppNetwork>
-				<Attribute Name="Unfolded" Type="STRING" Value="true"/>
-				<Attribute Name="width" Type="LREAL" Value="3026.666666666667"/>
-				<Attribute Name="height" Type="LREAL" Value="1606.6666666666667"/>
+				<Attribute Name="Unfolded" Value="true"/>
+				<Attribute Name="width" Type="LREAL" Value="3026.67"/>
+				<Attribute Name="height" Type="LREAL" Value="1606.67"/>
 			</SubApp>
-			<SubApp Name="Ex2a" Comment="Adapter with an event and data  &amp;#10;- trigger Fb1.REQ   &amp;#10;- expect Fb2.CNF with Fb2.DO1 := 5, Fb2.DO2 := TRUE" x="3406.666666666667" y="3246.666666666667">
+			<SubApp Name="Ex2a" Comment="Adapter with an event and data  &#10;- trigger Fb1.REQ   &#10;- expect Fb2.CNF with Fb2.DO1 := 5, Fb2.DO2 := TRUE" x="3406.67" y="3246.67">
 				<SubAppInterfaceList>
 				</SubAppInterfaceList>
 				<SubAppNetwork>
-					<FB Name="EnhancedAdapter" Type="EnhancedAdapter" Comment="" x="126.66666666666667" y="73.33333333333334">
+					<FB Name="EnhancedAdapter" Type="EnhancedAdapter" x="126.67" y="73.33">
 					</FB>
-					<FB Name="EnhancedAdapter2" Type="EnhancedAdapter2" Comment="" x="1666.6666666666667" y="100.0">
+					<FB Name="EnhancedAdapter2" Type="EnhancedAdapter2" x="1666.67" y="100">
 					</FB>
 					<AdapterConnections>
-						<Connection Source="EnhancedAdapter2.adp" Destination="EnhancedAdapter.adp" Comment="" dx1="80.0" dx2="80.0" dy="420.0"/>
+						<Connection Source="EnhancedAdapter2.adp" Destination="EnhancedAdapter.adp" dx1="80" dx2="80" dy="420"/>
 					</AdapterConnections>
 				</SubAppNetwork>
-				<Attribute Name="Unfolded" Type="STRING" Value="true"/>
-				<Attribute Name="width" Type="LREAL" Value="3666.666666666667"/>
-				<Attribute Name="height" Type="LREAL" Value="1533.3333333333335"/>
+				<Attribute Name="Unfolded" Value="true"/>
+				<Attribute Name="width" Type="LREAL" Value="3666.67"/>
+				<Attribute Name="height" Type="LREAL" Value="1533.33"/>
 			</SubApp>
-			<SubApp Name="Ex3a" Comment="Adapter with a WITH (do not update all data)  &amp;#10;- trigger Fb1.REQ   &amp;#10;- expect Fb2.CNF with Fb2.DO1 := 5, Fb2.DO2 := FALSE " x="3406.666666666667" y="4840.0">
+			<SubApp Name="Ex3a" Comment="Adapter with a WITH (do not update all data)  &#10;- trigger Fb1.REQ   &#10;- expect Fb2.CNF with Fb2.DO1 := 5, Fb2.DO2 := FALSE " x="3406.67" y="4840">
 				<SubAppInterfaceList>
 				</SubAppInterfaceList>
 				<SubAppNetwork>
-					<FB Name="EnhancedAdapterWith2" Type="EnhancedAdapterWith2" Comment="" x="2040.0" y="386.6666666666667">
+					<FB Name="EnhancedAdapterWith2" Type="EnhancedAdapterWith2" x="2040" y="386.67">
 					</FB>
-					<FB Name="EnhancedAdapterWith" Type="EnhancedAdapterWith" Comment="" x="306.6666666666667" y="293.33333333333337">
+					<FB Name="EnhancedAdapterWith" Type="EnhancedAdapterWith" x="306.67" y="293.33">
 					</FB>
 					<AdapterConnections>
-						<Connection Source="EnhancedAdapterWith2.adp" Destination="EnhancedAdapterWith.adp" Comment="" dx1="80.0" dx2="80.0" dy="360.0"/>
+						<Connection Source="EnhancedAdapterWith2.adp" Destination="EnhancedAdapterWith.adp" dx1="80" dx2="80" dy="360"/>
 					</AdapterConnections>
 				</SubAppNetwork>
-				<Attribute Name="Unfolded" Type="STRING" Value="true"/>
-				<Attribute Name="width" Type="LREAL" Value="3660.0"/>
-				<Attribute Name="height" Type="LREAL" Value="1920.0"/>
+				<Attribute Name="Unfolded" Value="true"/>
+				<Attribute Name="width" Type="LREAL" Value="3840"/>
+				<Attribute Name="height" Type="LREAL" Value="1920"/>
 			</SubApp>
-			<SubApp Name="Ex4a" Comment="analyze default values of adapter &amp;#10;trigger REQ &amp;#10;outputs show the 4 default values of the adapter" x="3420.0" y="6873.333333333334">
+			<SubApp Name="Ex4a" Comment="analyze default values of adapter &#10;trigger REQ &#10;outputs show the 4 default values of the adapter" x="3420" y="6873.33">
 				<SubAppInterfaceList>
 				</SubAppInterfaceList>
 				<SubAppNetwork>
-					<FB Name="DefaultOutputValueAdapter" Type="DefaultOutputValueAdapter" Comment="" x="660.0" y="340.0">
+					<FB Name="DefaultOutputValueAdapter" Type="DefaultOutputValueAdapter" x="660" y="340">
 					</FB>
 				</SubAppNetwork>
-				<Attribute Name="Unfolded" Type="STRING" Value="true"/>
-				<Attribute Name="width" Type="LREAL" Value="2720.0"/>
-				<Attribute Name="height" Type="LREAL" Value="2146.666666666667"/>
+				<Attribute Name="Unfolded" Value="true"/>
+				<Attribute Name="width" Type="LREAL" Value="2720"/>
+				<Attribute Name="height" Type="LREAL" Value="2146.67"/>
 			</SubApp>
-			<SubApp Name="Ex4b" Comment="analyze default values of adapter &amp;#10;trigger REQ &amp;#10;outputs show the 4 default values of the adapter" x="6306.666666666667" y="6880.0">
+			<SubApp Name="Ex4b" Comment="analyze default values of adapter &#10;trigger REQ &#10;outputs show the 4 default values of the adapter" x="6306.67" y="6880">
 				<SubAppInterfaceList>
 				</SubAppInterfaceList>
 				<SubAppNetwork>
-					<FB Name="DefaultOutputValueAdapter" Type="DefaultValueAdapter" Comment="" x="660.0" y="340.0">
+					<FB Name="DefaultOutputValueAdapter" Type="DefaultValueAdapter" x="660" y="340">
 					</FB>
 				</SubAppNetwork>
-				<Attribute Name="Unfolded" Type="STRING" Value="true"/>
-				<Attribute Name="width" Type="LREAL" Value="2720.0"/>
-				<Attribute Name="height" Type="LREAL" Value="2146.666666666667"/>
+				<Attribute Name="Unfolded" Value="true"/>
+				<Attribute Name="width" Type="LREAL" Value="2720"/>
+				<Attribute Name="height" Type="LREAL" Value="2146.67"/>
 			</SubApp>
 		</SubAppNetwork>
 	</Application>
-	<Device Name="RaspberryPI" Type="" Comment="" x="4506.666666666667" y="2020.0">
+	<Device Name="RaspberryPI" Type="" x="4506.67" y="2020">
 		<Parameter Name="MGR_ID" Value="&quot;localhost:61499&quot;"/>
 		<Attribute Name="Profile" Type="STRING" Value="HOLOBLOC"/>
 		<Attribute Name="Color" Type="STRING" Value="255,190,111"/>
-		<Resource Name="EMB_RES" Type="" Comment="" x="0.0" y="0.0">
+		<Resource Name="EMB_RES" Type="" x="0" y="0">
 			<FBNetwork>
 			</FBNetwork>
 		</Resource>
 	</Device>
-	<Segment Name="Ethernet_1" Type="" Comment="" x="7226.666666666667" y="1506.6666666666667" dx1="2000.0">
+	<Segment Name="Ethernet_1" Type="" x="7226.67" y="1506.67" dx1="2000">
 		<Attribute Name="Color" Type="STRING" Value="213,144,110"/>
 	</Segment>
-	<Segment Name="Ethernet" Type="" Comment="" x="8013.333333333334" y="2373.3333333333335" dx1="2000.0">
+	<Segment Name="Ethernet" Type="" x="8013.33" y="2373.33" dx1="2000">
 		<Attribute Name="Color" Type="STRING" Value="150,146,239"/>
 	</Segment>
 </System>


### PR DESCRIPTION
With the various changes to the expanded subapp size, most of the blocks were hidden behind interface bars. This commit updates the sizing and positioning to 4diac 3.0.2.